### PR TITLE
BC7 Compression Support + Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ baseq2/**/*.txt
 !baseq2/maps/sky/*.txt
 !baseq2/pics/flashlight_profile.png
 /baseq2/env
+
+# Texture compression tools
+tools/compress*

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ q2config.cfg
 save
 */docs
 ./basenac/
+basenac/
 
 CMakeSettings.json
 /network

--- a/compile_shaders.bat
+++ b/compile_shaders.bat
@@ -1,6 +1,6 @@
 @echo off
 
-IF "%BUILD_DIRECTORY%" == "" SET BUILD_DIRECTORY=build
+IF "%BUILD_DIRECTORY%" == "" SET BUILD_DIRECTORY=out\build\x64-Debug
 
 IF NOT EXIST %BUILD_DIRECTORY% (
 	echo build directory not found

--- a/inc/refresh/images.h
+++ b/inc/refresh/images.h
@@ -51,6 +51,7 @@ typedef enum {
     IM_TGA,
     IM_JPG,
     IM_PNG,
+    IM_KTX,
     IM_MAX
 } imageformat_t;
 

--- a/inc/refresh/images.h
+++ b/inc/refresh/images.h
@@ -51,7 +51,7 @@ typedef enum {
     IM_TGA,
     IM_JPG,
     IM_PNG,
-    IM_KTX,
+    IM_DDS,
     IM_MAX
 } imageformat_t;
 
@@ -59,8 +59,11 @@ typedef enum {
 typedef enum
 {
     PF_R8G8B8A8_UNORM = 0,
+    PF_R8G8B8A8_BC7_UNORM,
     PF_R16_UNORM
 } pixelformat_t;
+
+typedef int (*mip_size_cb_t)(int width, int height, uint32_t mip_level);
 
 typedef struct image_s {
     list_t          entry;
@@ -75,7 +78,9 @@ typedef struct image_s {
 	int             is_srgb;
 	uint64_t        last_modified;
 #if REF_VKPT
-    byte            *pix_data; // todo: add miplevels
+    byte            *pix_data;
+    uint32_t        mip_levels;
+    mip_size_cb_t   mip_size_cb; // Callback to calculate mip size
     pixelformat_t   pixel_format; // pixel format (only supported by VKPT renderer)
     vec3_t          light_color; // use this color if this is a light source
 	vec2_t          min_light_texcoord;

--- a/scripts/compress_color_tga.py
+++ b/scripts/compress_color_tga.py
@@ -59,9 +59,12 @@ non_compressed_size = 0
 
 for file in glob.iglob(recurse_path_tga, recursive=True):
     full_path = path(file)
-
-    if(file.endswith("_n.tga") or file.endswith("_light.tga")):
-        continue
+    
+    for i in ignore_if_in_file:
+        if(i in full_path):
+            print("Ignoring texture " + full_path)
+            ignore_texture = True
+            break
     else:
         color_textures.add(full_path)
         os.path.getsize(full_path)
@@ -89,15 +92,6 @@ try:
 
         if(texture in emissive_textures):
             print("Emissive texture detected, skipping...")
-            continue
-
-        ignore_texture = False
-        for i in ignore_if_in_file:
-            if(i in texture):
-                print("Ignoring texture...")
-                ignore_texture = True
-                break
-        if(ignore_texture):
             continue
 
 

--- a/scripts/compress_color_tga.py
+++ b/scripts/compress_color_tga.py
@@ -1,0 +1,101 @@
+# This python file will compress all the textures that are found in baseq2
+# If requests module is not installed, run the following command:
+# pip install requests
+
+import glob
+import os
+from zipfile import ZipFile
+import time
+import shutil
+
+def path(path):
+    if(os.name == "nt"):
+        return os.path.abspath(path).replace("/", "\\")
+    else:
+        return os.path.abspath(path).replace("\\", "/")
+    
+
+data_folder = path("../basenac")
+
+recurse_path_tga = path(f"{data_folder}/**/*.tga")
+recurse_path_mat = path(f"{data_folder}/**/*.mat")
+
+compressonator_version = "4.4.19"
+os_name = "win64" # win64, amd64, Linux; Only win64 is tested
+
+compressonator_url = f"https://github.com/GPUOpen-Tools/compressonator/releases/download/V{compressonator_version}/compressonatorcli-{compressonator_version}-{os_name}.zip"
+tools_folder = path("../tools/")
+compressonator_folder_name = f"compressonatorcli-{compressonator_version}-{os_name}"
+compressonator_cli = path(f"{tools_folder}/{compressonator_folder_name}/compressonatorcli.exe")
+
+def extract_zip(zip_path, extract_path):
+    with ZipFile(zip_path, mode="r") as zf:
+        zf.extractall(extract_path)
+    os.remove(zip_path)
+if(os.path.exists(compressonator_cli)):
+    print("Compressonator is already installed")
+else:
+    print("Compresonator is not installed, downloading now...")
+
+    os.system(f"curl -L {compressonator_url} -o compressonator.zip")
+
+    extract_zip("compressonator.zip", tools_folder)
+
+
+compressed_folder = path(f"{data_folder}/compressed/")
+
+if(not os.path.exists(compressed_folder)):
+    os.mkdir(compressed_folder)
+
+color_textures = set()
+emissive_textures = set()
+
+for file in glob.iglob(recurse_path_tga, recursive=True):
+    full_path = path(file)
+
+    if(file.endswith("_n.tga") or file.endswith("_light.tga")):
+        continue
+    else:
+        color_textures.add(full_path)
+
+for file in glob.iglob(recurse_path_mat, recursive=True):
+    full_path = path(file)
+    with open(full_path, "r") as f:
+        for line in f:
+            line = line.strip()
+            args = line.split(" ")
+            if(args[0] == "texture_emissive"):
+                emissive_textures.add(path(f"{data_folder}/{args[1]}"))
+
+
+compressonator_args = "-fd BC7 -EncodeWith GPU -mipsize 16 -silent"
+
+try:
+    for texture in color_textures:
+        print("=====================================")
+        print(f"Compressing {texture}")
+
+        if(texture in emissive_textures):
+            print("Emissive texture detected, skipping...")
+            continue
+
+        output_path = path(f"{compressed_folder}/{os.path.basename(texture).replace('.tga', '.dds')}")
+
+        if(os.path.exists(output_path)):
+            print("File already exists, skipping...")
+            continue
+
+        command = f"{compressonator_cli} {compressonator_args} {texture} {output_path}"
+
+        t1 = time.time()
+        os.system(command)
+        t2 = time.time()
+        
+        print(f"Outputted to {output_path}")
+        print(f"Time elapsed: {t2 - t1} seconds")
+    
+except KeyboardInterrupt:
+    print("Keyboard interrupt detected, exiting...")
+
+input("Press enter to exit...")
+

--- a/scripts/compress_color_tga.py
+++ b/scripts/compress_color_tga.py
@@ -32,6 +32,7 @@ tools_folder = path("../tools/")
 compressonator_folder_name = f"compressonatorcli-{compressonator_version}-{os_name}"
 compressonator_cli = path(f"{tools_folder}/{compressonator_folder_name}/compressonatorcli.exe")
 
+
 def extract_zip(zip_path, extract_path):
     with ZipFile(zip_path, mode="r") as zf:
         zf.extractall(extract_path)
@@ -54,6 +55,8 @@ if(not os.path.exists(compressed_folder)):
 color_textures = set()
 emissive_textures = set()
 
+non_compressed_size = 0
+
 for file in glob.iglob(recurse_path_tga, recursive=True):
     full_path = path(file)
 
@@ -61,6 +64,8 @@ for file in glob.iglob(recurse_path_tga, recursive=True):
         continue
     else:
         color_textures.add(full_path)
+        os.path.getsize(full_path)
+        non_compressed_size += os.path.getsize(full_path)
 
 for file in glob.iglob(recurse_path_mat, recursive=True):
     full_path = path(file)
@@ -115,5 +120,11 @@ try:
 except KeyboardInterrupt:
     print("Keyboard interrupt detected, exiting...")
 
+compressed_size = 0
+for file in glob.iglob(path(f"{compressed_folder}/*.dds"), recursive=True):
+    compressed_size += os.path.getsize(file)
+
+print(f"Total size of uncompressed textures: {non_compressed_size / 1024.0 / 1024.0} MB")
+print(f"Total size of compressed textures: {compressed_size / 1024.0 / 1024.0} MB")
 input("Press enter to exit...")
 

--- a/scripts/compress_color_tga.py
+++ b/scripts/compress_color_tga.py
@@ -8,6 +8,9 @@ from zipfile import ZipFile
 import time
 import shutil
 
+
+replace_existing = False
+
 def path(path):
     if(os.name == "nt"):
         return os.path.abspath(path).replace("/", "\\")
@@ -15,6 +18,7 @@ def path(path):
         return os.path.abspath(path).replace("\\", "/")
     
 
+ignore_if_in_file = ["_n.tga", "_light.tga", "m_cursor", "ft.tga", "bk.tga", "up.tga", "dn.tga", "rt.tga", "lf.tga"]
 data_folder = path("../basenac")
 
 recurse_path_tga = path(f"{data_folder}/**/*.tga")
@@ -70,6 +74,9 @@ for file in glob.iglob(recurse_path_mat, recursive=True):
 
 compressonator_args = "-fd BC7 -EncodeWith GPU -mipsize 16 -silent"
 
+# copy all the color textures to a temp folder
+
+
 try:
     for texture in color_textures:
         print("=====================================")
@@ -79,11 +86,22 @@ try:
             print("Emissive texture detected, skipping...")
             continue
 
+        ignore_texture = False
+        for i in ignore_if_in_file:
+            if(i in texture):
+                print("Ignoring texture...")
+                ignore_texture = True
+                break
+        if(ignore_texture):
+            continue
+
+
         output_path = path(f"{compressed_folder}/{os.path.basename(texture).replace('.tga', '.dds')}")
 
-        if(os.path.exists(output_path)):
-            print("File already exists, skipping...")
-            continue
+        if(not replace_existing):
+            if(os.path.exists(output_path)):
+                print("File already exists, skipping...")
+                continue
 
         command = f"{compressonator_cli} {compressonator_args} {texture} {output_path}"
 

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -346,6 +346,11 @@ static bool supports_extended_pixel_format(void)
 	return true;
 }
 
+IMG_LOAD(KTX)
+{
+    return -1;
+}
+
 IMG_LOAD(STB)
 {
 	int w, h, channels;
@@ -875,7 +880,8 @@ static const struct {
     { "wal", IMG_LoadWAL },
     { "tga", IMG_LoadSTB },
     { "jpg", IMG_LoadSTB },
-    { "png", IMG_LoadSTB }
+    { "png", IMG_LoadSTB },
+    { "ktx", IMG_LoadKTX }
 };
 
 static imageformat_t    img_search[IM_MAX];
@@ -1214,6 +1220,7 @@ static void r_texture_formats_changed(cvar_t *self)
             case 't': case 'T': i = IM_TGA; break;
             case 'j': case 'J': i = IM_JPG; break;
             case 'p': case 'P': i = IM_PNG; break;
+            case 'k': case 'K': i = IM_KTX; break;
             default: continue;
         }
 
@@ -1484,7 +1491,7 @@ static image_t *find_or_load_image(const char *name, size_t len,
             // fill in some basic info
             memcpy(image->name, name, len + 1);
             image->baselen = len - 4;
-            ret = try_load_image_candidate(image, NULL, 0, &pic, type, flags, !!allow_override, try_location);
+            ret = try_load_image_candidate(image, NULL, 0, &pic, type, flags, allow_override, try_location);
             image->flags |= location_flag;
 
             if (ret >= 0)
@@ -1862,7 +1869,7 @@ void IMG_Init(void)
     Q_assert(!r_numImages);
 
     r_override_textures = Cvar_Get("r_override_textures", "1", CVAR_FILES);
-    r_texture_formats = Cvar_Get("r_texture_formats", "pjt", 0);
+    r_texture_formats = Cvar_Get("r_texture_formats", "pjtk", 0);
     r_texture_formats->changed = r_texture_formats_changed;
     r_texture_formats_changed(r_texture_formats);
     r_texture_overrides = Cvar_Get("r_texture_overrides", "-1", CVAR_FILES);

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -400,7 +400,6 @@ static int IMG_LoadDDS(byte* rawdata, size_t rawlen, image_t* image, byte** pic)
     image->upload_height = image->height = header->height;
     image->mip_levels = header->mipMapCount;
     image->mip_size_cb = DDS_mip_size;
-    image->flags &= ~IF_SRGB;
 
     return Q_ERR_SUCCESS;
 

--- a/src/refresh/images.c
+++ b/src/refresh/images.c
@@ -356,7 +356,7 @@ int DDS_mip_size(int w, int h, int mip)
     return ((wi + 3) / 4) * ((he + 3) / 4) * 16;
 }
 
-static int IMG_LoadDDS(byte* rawdata, size_t rawlen, image_t* image, byte** pic)
+IMG_LOAD(DDS)
 {
     DDS_HEADER* header = (DDS_HEADER*)rawdata;
     DDS_HEADER_DXT10* header10 = rawdata + sizeof(DDS_HEADER);

--- a/src/refresh/vkpt/physical_sky.c
+++ b/src/refresh/vkpt/physical_sky.c
@@ -874,9 +874,15 @@ vkpt_physical_sky_update_ubo(QVKUniformBuffer_t* ubo, const sun_light_t* light, 
 	// sun
 
 	ubo->sun_bounce_scale = sun_bounce->value;
-	ubo->sun_tan_half_angle = tanf(light->angular_size_rad * 0.5f);
-	ubo->sun_cos_half_angle = cosf(light->angular_size_rad * 0.5f);
-	ubo->sun_solid_angle = 2 * M_PI * (float)(1.0 - cos(light->angular_size_rad * 0.5)); // use double for precision
+	// This affects the brightness of the sun depending on the sun size, but we don't want that even if it's physically correct
+	//ubo->sun_tan_half_angle = tanf(light->angular_size_rad * 0.5f);
+	//ubo->sun_cos_half_angle = cosf(light->angular_size_rad * 0.5f);
+	//ubo->sun_solid_angle = 2 * M_PI * (float)(1.0 - cos(light->angular_size_rad * 0.5)); // use double for precision
+	// This ensures all lighting is constant regardless of the sun size
+	ubo->sun_tan_half_angle = tanf(0.01 * 0.5f);
+	ubo->sun_cos_half_angle = cosf(0.01 * 0.5f);
+	ubo->sun_cosmetic_size = tanf(light->angular_size_rad * 0.5f) / 100.f; // size of the sun according to sun_angle
+	ubo->sun_solid_angle = 2 * M_PI * (float)(1.0 - cos(0.01 * 0.5)); // use double for precision
 
 	if (sun_surface_map_render->integer)
 		ubo->sun_surface_map = physical_sky_sun_surface_map; // the texture map for the sun

--- a/src/refresh/vkpt/physical_sky.c
+++ b/src/refresh/vkpt/physical_sky.c
@@ -934,6 +934,7 @@ vkpt_physical_sky_update_ubo(QVKUniformBuffer_t* ubo, const sun_light_t* light, 
 		if (physical_sky_cloud_overlay->value > 0)
 			flags = flags | PHYSICAL_SKY_FLAG_OVERLAY_CLOUDS;
 
+
 		ubo->physical_sky_flags = flags;
 
 		// compute approximation of reflected radiance from ground

--- a/src/refresh/vkpt/physical_sky.c
+++ b/src/refresh/vkpt/physical_sky.c
@@ -1094,8 +1094,8 @@ void InitialiseSkyCVars()
 	physical_sky_cloud_overlay_texture0 = Cvar_Get("physical_sky_cloud_overlay_texture0", "", 0);
 	physical_sky_cloud_overlay_texture1 = Cvar_Get("physical_sky_cloud_overlay_texture1", "", 0);
 
-	physical_sky_cloud_overlay_brightness0 = Cvar_Get("physical_sky_cloud_overlay_brightness0", "0", 0);
-	physical_sky_cloud_overlay_brightness1 = Cvar_Get("physical_sky_cloud_overlay_brightness1", "0", 0);
+	physical_sky_cloud_overlay_brightness0 = Cvar_Get("physical_sky_cloud_overlay_brightness0", "1", 0);
+	physical_sky_cloud_overlay_brightness1 = Cvar_Get("physical_sky_cloud_overlay_brightness1", "1", 0);
 
 	physical_sky_cloud_overlay_scale0 = Cvar_Get("physical_sky_cloud_overlay_scale0", "50.0", 0);
 	physical_sky_cloud_overlay_scale1 = Cvar_Get("physical_sky_cloud_overlay_scale1", "50.0", 0);

--- a/src/refresh/vkpt/physical_sky.c
+++ b/src/refresh/vkpt/physical_sky.c
@@ -82,6 +82,7 @@ cvar_t *physical_sky_brightness;
 cvar_t *physical_sky_sun_texture;
 
 cvar_t *physical_sky_planet_radius;
+cvar_t *physical_sky_planet_atmosphere;
 cvar_t *physical_sky_planet_render;
 cvar_t *physical_sky_planet_texture;
 
@@ -977,6 +978,7 @@ vkpt_physical_sky_update_ubo(QVKUniformBuffer_t* ubo, const sun_light_t* light, 
     ubo->planet_normal_map = physical_sky_planet_normal_map;
 
 	ubo->planet_radius = physical_sky_planet_radius->value;
+	ubo->planet_radius_ratio = physical_sky_planet_atmosphere->value ? 0.945f : 1.0f;
 	ubo->physical_sky_flags |= physical_sky_planet_render->integer ? PHYSICAL_SKY_FLAG_DRAW_PLANET : 0x0;
 	ubo->physical_sky_flags |= sun_render->integer ? PHYSICAL_SKY_FLAG_DRAW_SUN : 0x0;
 
@@ -1116,6 +1118,9 @@ void InitialiseSkyCVars()
 
 	physical_sky_planet_radius = Cvar_Get("planet_radius", "0.4", 0);
 	physical_sky_planet_radius->changed = physical_sky_cvar_changed;
+
+	physical_sky_planet_atmosphere = Cvar_Get("planet_atmosphere", "1", 0);
+	physical_sky_planet_atmosphere->changed = physical_sky_cvar_changed;
 
 	physical_sky_planet_texture = Cvar_Get("planet_texture", "planet", 0);
 

--- a/src/refresh/vkpt/physical_sky.c
+++ b/src/refresh/vkpt/physical_sky.c
@@ -391,11 +391,9 @@ vkpt_physical_sky_endRegistration()
 		planet_normal_path[0] = '\0';
 
 		{
-			strcpy(planet_albedo_path, "env/"); // first has to be strcpy
 			strcat(planet_albedo_path, physical_sky_planet_texture->string);
 			strcat(planet_albedo_path, "_albedo.tga");
 
-			strcpy(planet_normal_path, "env/");
 			strcat(planet_normal_path, physical_sky_planet_texture->string);
 			strcat(planet_normal_path, "_normal.tga");
 		}
@@ -412,7 +410,6 @@ vkpt_physical_sky_endRegistration()
 	char file_path[64];
 	file_path[0] = '\0';
 
-	strcpy(file_path, "env/");
 	strcat(file_path, physical_sky_sun_texture->string);
 	strcat(file_path, ".tga");
 

--- a/src/refresh/vkpt/physical_sky.c
+++ b/src/refresh/vkpt/physical_sky.c
@@ -66,6 +66,9 @@ cvar_t *physical_sky_cloud_overlay_height;
 cvar_t* physical_sky_cloud_overlay_texture0;
 cvar_t* physical_sky_cloud_overlay_texture1;
 
+cvar_t* physical_sky_cloud_overlay_brightness0;
+cvar_t* physical_sky_cloud_overlay_brightness1;
+
 cvar_t *physical_sky_cloud_overlay_speed0;
 cvar_t *physical_sky_cloud_overlay_scale0;
 cvar_t *physical_sky_cloud_overlay_direction0;
@@ -964,6 +967,8 @@ vkpt_physical_sky_update_ubo(QVKUniformBuffer_t* ubo, const sun_light_t* light, 
 	ubo->cloud_overlay_scale1 = physical_sky_cloud_overlay_scale1->value;
 	ubo->cloud_overlay_direction1[0] = cosf(ConvertAngleToRadians(physical_sky_cloud_overlay_direction1->value)) * physical_sky_cloud_overlay_speed1->value;
 	ubo->cloud_overlay_direction1[1] = sinf(ConvertAngleToRadians(physical_sky_cloud_overlay_direction1->value)) * physical_sky_cloud_overlay_speed1->value;
+	ubo->cloud_overlay_brightness0 = physical_sky_cloud_overlay_brightness0->value;
+	ubo->cloud_overlay_brightness1 = physical_sky_cloud_overlay_brightness1->value;
 
 
 	// planet
@@ -1088,6 +1093,9 @@ void InitialiseSkyCVars()
 
 	physical_sky_cloud_overlay_texture0 = Cvar_Get("physical_sky_cloud_overlay_texture0", "", 0);
 	physical_sky_cloud_overlay_texture1 = Cvar_Get("physical_sky_cloud_overlay_texture1", "", 0);
+
+	physical_sky_cloud_overlay_brightness0 = Cvar_Get("physical_sky_cloud_overlay_brightness0", "0", 0);
+	physical_sky_cloud_overlay_brightness1 = Cvar_Get("physical_sky_cloud_overlay_brightness1", "0", 0);
 
 	physical_sky_cloud_overlay_scale0 = Cvar_Get("physical_sky_cloud_overlay_scale0", "50.0", 0);
 	physical_sky_cloud_overlay_scale1 = Cvar_Get("physical_sky_cloud_overlay_scale1", "50.0", 0);

--- a/src/refresh/vkpt/post_process.c
+++ b/src/refresh/vkpt/post_process.c
@@ -87,12 +87,13 @@ VkResult vkpt_postprocess_record_cmd_buffer(VkCommandBuffer cmd_buf)
 VkResult vkpt_postprocess_destroy()
 {
 	vkDestroyPipelineLayout(qvk.device, postprocess_pipeline_layout, NULL);
+	postprocess_pipeline_layout = 0;
 	return VK_SUCCESS;
 }
 
 VkResult vkpt_postprocess_destroy_pipeline()
 {
 	vkDestroyPipeline(qvk.device, postprocess_pipeline, NULL);
-
+	postprocess_pipeline = 0;
 	return VK_SUCCESS;
 }

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -245,6 +245,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	\
 	GLOBAL_UBO_VAR_LIST_DO(float,			cloud_overlay_brightness0) \
 	GLOBAL_UBO_VAR_LIST_DO(float,			cloud_overlay_brightness1) \
+	GLOBAL_UBO_VAR_LIST_DO(float,			planet_radius_ratio) \
 	GLOBAL_UBO_VAR_LIST_DO(int,		        enable_underwater_warp) \
 	\
 	UBO_CVAR_LIST // WARNING: Do not put any other members into global_ubo after this: the CVAR list is not vec4-aligned

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -243,6 +243,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	GLOBAL_UBO_VAR_LIST_DO(vec2,			cloud_overlay_direction0) \
 	GLOBAL_UBO_VAR_LIST_DO(vec2,			cloud_overlay_direction1) \
 	\
+	GLOBAL_UBO_VAR_LIST_DO(float,			cloud_overlay_brightness0) \
+	GLOBAL_UBO_VAR_LIST_DO(float,			cloud_overlay_brightness1) \
 	GLOBAL_UBO_VAR_LIST_DO(int,		        enable_underwater_warp) \
 	\
 	UBO_CVAR_LIST // WARNING: Do not put any other members into global_ubo after this: the CVAR list is not vec4-aligned

--- a/src/refresh/vkpt/shader/global_ubo.h
+++ b/src/refresh/vkpt/shader/global_ubo.h
@@ -228,10 +228,10 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 	GLOBAL_UBO_VAR_LIST_DO(ShaderFogVolume, fog_volumes[MAX_FOG_VOLUMES]) \
 	\
 	GLOBAL_UBO_VAR_LIST_DO(int,             weapon_left_handed) \
-	\
-	GLOBAL_UBO_VAR_LIST_DO(float,			sun_surface_map_scale) \
 	GLOBAL_UBO_VAR_LIST_DO(int,				sun_surface_map) \
-	GLOBAL_UBO_VAR_LIST_DO(int,		        enable_underwater_warp) \
+	GLOBAL_UBO_VAR_LIST_DO(float,			sun_surface_map_scale) \
+	GLOBAL_UBO_VAR_LIST_DO(float,			sun_cosmetic_size) \
+	\
 	GLOBAL_UBO_VAR_LIST_DO(vec3,			planet_position) \
 	GLOBAL_UBO_VAR_LIST_DO(float,           planet_radius) \
     \
@@ -242,6 +242,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
     \
 	GLOBAL_UBO_VAR_LIST_DO(vec2,			cloud_overlay_direction0) \
 	GLOBAL_UBO_VAR_LIST_DO(vec2,			cloud_overlay_direction1) \
+	\
+	GLOBAL_UBO_VAR_LIST_DO(int,		        enable_underwater_warp) \
 	\
 	UBO_CVAR_LIST // WARNING: Do not put any other members into global_ubo after this: the CVAR list is not vec4-aligned
 

--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -119,8 +119,8 @@ env_map(vec3 direction, bool remove_sun)
 			//if (dot_sun > (0.9999))
 			// Sun angle, so allow sun to get bigger
 
-			const float sun_size = (1 - (global_ubo.sun_tan_half_angle / 100.f));
-			const float sun_falloff = 1 - (global_ubo.sun_tan_half_angle / 100.f / 1.f);
+			const float sun_size = 1 - (global_ubo.sun_cosmetic_size);
+			const float sun_falloff = 1 - (global_ubo.sun_cosmetic_size);
 			if (dot_sun > sun_size)
 			{
 				vec3 sun_color = global_ubo.sun_color * dot_sun * smoothstep(sun_size, sun_falloff, dot_sun);

--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -118,9 +118,15 @@ env_map(vec3 direction, bool remove_sun)
 			float dot_sun = dot(direction, global_ubo.sun_direction_envmap);
 			//if (dot_sun > (0.9999))
 			// Sun angle, so allow sun to get bigger
-			if (dot_sun > (1 - (global_ubo.sun_tan_half_angle / 100.f)))
+
+			const float sun_size = (1 - (global_ubo.sun_tan_half_angle / 100.f));
+			const float sun_falloff = 1 - (global_ubo.sun_tan_half_angle / 100.f / 1.f);
+			if (dot_sun > sun_size)
 			{
-				vec3 sun_color = global_ubo.sun_color * pow(dot_sun, 100);
+				vec3 sun_color = global_ubo.sun_color * dot_sun * smoothstep(sun_size, sun_falloff, dot_sun);
+
+
+
 				if (global_ubo.sun_surface_map != -1)
 				{
 					// create orthonormal basis for sun

--- a/src/refresh/vkpt/shader/path_tracer_rgen.h
+++ b/src/refresh/vkpt/shader/path_tracer_rgen.h
@@ -120,12 +120,10 @@ env_map(vec3 direction, bool remove_sun)
 			// Sun angle, so allow sun to get bigger
 
 			const float sun_size = 1 - (global_ubo.sun_cosmetic_size);
-			const float sun_falloff = 1 - (global_ubo.sun_cosmetic_size);
+			const float sun_falloff = 1 - (global_ubo.sun_cosmetic_size) * 0.7;
 			if (dot_sun > sun_size)
 			{
 				vec3 sun_color = global_ubo.sun_color * dot_sun * smoothstep(sun_size, sun_falloff, dot_sun);
-
-
 
 				if (global_ubo.sun_surface_map != -1)
 				{

--- a/src/refresh/vkpt/shader/physical_sky.comp
+++ b/src/refresh/vkpt/shader/physical_sky.comp
@@ -389,10 +389,7 @@ void main() {
         sun_direct_radiance /= global_ubo.sun_solid_angle;
         sun_direct_radiance *= pow(clamp((dot(eyeVec, sun.direction) - global_ubo.sun_cos_half_angle) * 1000 + 0.875, 0, 1), 10);
         
-        // sun_render cvar, 0 = off, 1 = on. This is a toggle to make the sun disc visible in the sky.
-        // This one is "we don't want the sun disc"
-        vec3 out_radiance = (draw_sun != 0 ? sun_direct_radiance : vec3(0,0,0)) + radiance;
-
+        vec3 out_radiance = radiance;
         radiance += sun_direct_radiance;
 
 		
@@ -425,20 +422,6 @@ void main() {
             vec2 frac_pos = fpos.xy / hres;
             pixel_solid_angle /= sqrt((1 + frac_pos.x * frac_pos.x) * (1 + frac_pos.y * frac_pos.y));
 
-            if(global_ubo.sun_surface_map != -1)
-            {
-                // create orthonormal basis for sun
-                const vec3 up = vec3(0,1,0);
-                const vec3 sun_x = normalize(cross(sun.direction, up));
-                const vec3 sun_y = normalize(cross(sun_x, sun.direction));
-        
-                // project texture to sun disk
-                vec2 sun_uv = vec2(dot(sun_x, eyeVec), dot(sun_y, eyeVec)) / global_ubo.sun_surface_map_scale;
-                sun_uv = sun_uv * 0.5 + 0.5;
-
-                radiance *= vec3(global_textureLod(global_ubo.sun_surface_map, sun_uv, 0));
-                out_radiance *= vec3(global_textureLod(global_ubo.sun_surface_map, sun_uv, 0));
-            }
             atomicAdd(sun_color_buffer.accum_sun_color.r, int(radiance.r * pixel_solid_angle * SUN_COLOR_ACCUMULATOR_FIXED_POINT_SCALE));
             atomicAdd(sun_color_buffer.accum_sun_color.g, int(radiance.g * pixel_solid_angle * SUN_COLOR_ACCUMULATOR_FIXED_POINT_SCALE));
             atomicAdd(sun_color_buffer.accum_sun_color.b, int(radiance.b * pixel_solid_angle * SUN_COLOR_ACCUMULATOR_FIXED_POINT_SCALE));

--- a/src/refresh/vkpt/shader/physical_sky_space.comp
+++ b/src/refresh/vkpt/shader/physical_sky_space.comp
@@ -381,6 +381,7 @@ void main() {
 	planet.normalMap = global_ubo.planet_normal_map;
 	planet.outerRadius = global_ubo.planet_radius;
 	planet.position = global_ubo.planet_position;
+	planet.radiusRatio = global_ubo.planet_radius_ratio;
 	vec4 planet_color = integratePlanet(sun, planet, eyeVec);
 	radiance = mix(radiance, planet_color.rgb, planet_color.a);
 	out_radiance = mix(out_radiance, planet_color.rgb, planet_color.a);

--- a/src/refresh/vkpt/shader/physical_sky_space.comp
+++ b/src/refresh/vkpt/shader/physical_sky_space.comp
@@ -373,7 +373,7 @@ void main() {
 
 	// sun_render cvar, 0 = off, 1 = on. This is a toggle to make the sun disc visible in the sky.
     // This one is "we don't want the sun disc"
-    vec3 out_radiance = (draw_sun != 0 ? sun_direct_radiance : vec3(0,0,0)) + radiance;
+    vec3 out_radiance = radiance;
 	radiance += sun_direct_radiance;
 
 	// planet
@@ -392,20 +392,6 @@ void main() {
         vec2 frac_pos = fpos.xy / hres;
         pixel_solid_angle /= sqrt((1 + frac_pos.x * frac_pos.x) * (1 + frac_pos.y * frac_pos.y));
 
-		if(global_ubo.sun_surface_map != -1)
-        {
-            // create orthonormal basis for sun
-            const vec3 up = vec3(0,1,0);
-            const vec3 sun_x = normalize(cross(sun.direction, up));
-            const vec3 sun_y = normalize(cross(sun_x, sun.direction));
-        
-            // project texture to sun disk
-            vec2 sun_uv = vec2(dot(sun_x, eyeVec), dot(sun_y, eyeVec)) / global_ubo.sun_surface_map_scale;
-            sun_uv = sun_uv * 0.5 + 0.5;
-
-            radiance *= vec3(global_textureLod(global_ubo.sun_surface_map, sun_uv, 0));
-			out_radiance *= vec3(global_textureLod(global_ubo.sun_surface_map, sun_uv, 0));
-         }
 
         atomicAdd(sun_color_buffer.accum_sun_color.r, int(radiance.r * pixel_solid_angle * SUN_COLOR_ACCUMULATOR_FIXED_POINT_SCALE));
         atomicAdd(sun_color_buffer.accum_sun_color.g, int(radiance.g * pixel_solid_angle * SUN_COLOR_ACCUMULATOR_FIXED_POINT_SCALE));

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -37,7 +37,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "sky.h"
 
-#define OVERLAY_CLOUD_HEIHGT 30
+#define OVERLAY_CLOUD_HEIGT 30 // height of the clouds in world units, the higher they are the smaller they appear
 #define OVERLAY_CLOUD_CURVATURE 0.7 // 0 = flat, 1 = full curvature
 #define OVERLAY_CLOUD_FALLOFF 0.1 // falloff at the horizon, 0.1 is good, 0.5 is halfway between horizon and zenith, 0 is strictly at the horizon
 
@@ -122,7 +122,7 @@ void generate_rng_seed(ivec2 ipos, bool is_odd_checkerboard)
 vec2 intersect_plane(vec3 origin, vec3 direction)
 {
 	float curvature = sin((direction.z * M_PI) * OVERLAY_CLOUD_CURVATURE);
-	float t = (OVERLAY_CLOUD_HEIHGT * curvature - origin.y) / direction.z;
+	float t = (OVERLAY_CLOUD_HEIGT * curvature - origin.y) / direction.z;
 	vec3 intersection = origin + t * direction.xzy;
 	return intersection.xz;
 }

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -224,9 +224,10 @@ main()
 				vec4 cloud_color1 = global_texture(global_ubo.cloud_overlay_map1, plane_uv1);
 				
 				// first layer clouds
-				env = mix(env, cloud_color1.rgb, cloud_color1.a);
+				// Multiply by sun luminance to get the correct color, because otherwise the autoexposure will make them too bright
+				env = mix(env, cloud_color1.rgb * sun_color_ubo.sun_luminance, cloud_color1.a);
 				// second layer clouds
-				env = mix(env, cloud_color0.rgb, cloud_color0.a);
+				env = mix(env, cloud_color0.rgb * sun_color_ubo.sun_luminance, cloud_color0.a) ;
 			}
 		}
 

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -224,9 +224,9 @@ main()
 				
 				// second layer clouds
 				// Multiply by sun luminance to get the correct color, because otherwise the autoexposure will make them too bright
-				env = mix(env, cloud_color1.rgb * sun_color_ubo.sun_luminance, cloud_color1.a * falloff);
+				env = mix(env, cloud_color1.rgb * sun_color_ubo.sun_luminance * global_ubo.cloud_overlay_brightness1, cloud_color1.a * falloff);
 				// fist layer clouds
-				env = mix(env, cloud_color0.rgb * sun_color_ubo.sun_luminance, cloud_color0.a * falloff);
+				env = mix(env, cloud_color0.rgb * sun_color_ubo.sun_luminance * global_ubo.cloud_overlay_brightness0, cloud_color0.a * falloff);
 				//env = mix(env, vec3(plane_uv0, 0), 1);
 
 			}

--- a/src/refresh/vkpt/shader/primary_rays.rgen
+++ b/src/refresh/vkpt/shader/primary_rays.rgen
@@ -37,7 +37,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include "sky.h"
 
-#define OVERLAY_CLOUD_HEIHGT 10
+#define OVERLAY_CLOUD_HEIHGT 30
+#define OVERLAY_CLOUD_CURVATURE 0.7 // 0 = flat, 1 = full curvature
+#define OVERLAY_CLOUD_FALLOFF 0.1 // falloff at the horizon, 0.1 is good, 0.5 is halfway between horizon and zenith, 0 is strictly at the horizon
 
 Ray
 get_primary_ray(vec2 screen_pos)
@@ -119,17 +121,11 @@ void generate_rng_seed(ivec2 ipos, bool is_odd_checkerboard)
 // Returns the uv coordinate of the plane
 vec2 intersect_plane(vec3 origin, vec3 direction)
 {
-
-	float t = (OVERLAY_CLOUD_HEIHGT - origin.y) / direction.z;
+	float curvature = sin((direction.z * M_PI) * OVERLAY_CLOUD_CURVATURE);
+	float t = (OVERLAY_CLOUD_HEIHGT * curvature - origin.y) / direction.z;
 	vec3 intersection = origin + t * direction.xzy;
 	return intersection.xz;
 }
-
-vec2 parallax_mapping(vec2 texCoords, float height, vec3 viewDir)
-{ 
-    vec2 p = viewDir.xy / viewDir.z * height;
-    return texCoords - p;    
-} 
 
 void
 main()
@@ -205,17 +201,20 @@ main()
 		vec3 env = env_map(ray.direction, false);	
 		env *= global_ubo.pt_env_scale;
 
-		float terrain_depth = texture(IMG_TERRAIN_DEPTH, ray.direction.xzy).r;
-		if(((global_ubo.physical_sky_flags & PHYSICAL_SKY_FLAG_OVERLAY_CLOUDS) != 0) && (terrain_depth <= 0.0))
+		if(((global_ubo.physical_sky_flags & PHYSICAL_SKY_FLAG_OVERLAY_CLOUDS) != 0))
 		{
+			//vec2 plane_uv0 = vec2(0);
+			//float t = ellipseIntersection(ray.direction,  plane_uv0);
 			vec2 plane_uv0 = intersect_plane(vec3(0,0,0), ray.direction);
 
 			if(plane_uv0 != vec2(0))
 			{
-				vec2 plane_uv1 = parallax_mapping(plane_uv0, 1, ray.direction); // The top is the only one that needs parallax
+				const float falloff = smoothstep(OVERLAY_CLOUD_FALLOFF, 1, ray.direction.z);
 
-				plane_uv1 /= global_ubo.cloud_overlay_scale1;
+				vec2 plane_uv1 = plane_uv0;
+
 				plane_uv0 /= global_ubo.cloud_overlay_scale0;
+				plane_uv1 /= global_ubo.cloud_overlay_scale1;
 
 				plane_uv0 +=  global_ubo.cloud_overlay_direction0 * global_ubo.time; // animate the clouds
 				plane_uv1 += global_ubo.cloud_overlay_direction1 * global_ubo.time;
@@ -223,11 +222,13 @@ main()
 				vec4 cloud_color0 = global_texture(global_ubo.cloud_overlay_map0, plane_uv0);
 				vec4 cloud_color1 = global_texture(global_ubo.cloud_overlay_map1, plane_uv1);
 				
-				// first layer clouds
-				// Multiply by sun luminance to get the correct color, because otherwise the autoexposure will make them too bright
-				env = mix(env, cloud_color1.rgb * sun_color_ubo.sun_luminance, cloud_color1.a);
 				// second layer clouds
-				env = mix(env, cloud_color0.rgb * sun_color_ubo.sun_luminance, cloud_color0.a) ;
+				// Multiply by sun luminance to get the correct color, because otherwise the autoexposure will make them too bright
+				env = mix(env, cloud_color1.rgb * sun_color_ubo.sun_luminance, cloud_color1.a * falloff);
+				// fist layer clouds
+				env = mix(env, cloud_color0.rgb * sun_color_ubo.sun_luminance, cloud_color0.a * falloff);
+				//env = mix(env, vec3(plane_uv0, 0), 1);
+
 			}
 		}
 

--- a/src/refresh/vkpt/textures.c
+++ b/src/refresh/vkpt/textures.c
@@ -1531,7 +1531,7 @@ static VkFormat get_image_format(image_t *q_img)
 	case PF_R8G8B8A8_UNORM:
 		return q_img->is_srgb ? VK_FORMAT_R8G8B8A8_SRGB : VK_FORMAT_R8G8B8A8_UNORM;
 	case PF_R8G8B8A8_BC7_UNORM:
-		return VK_FORMAT_BC7_SRGB_BLOCK;
+		return q_img->is_srgb ? VK_FORMAT_BC7_SRGB_BLOCK : VK_FORMAT_BC7_UNORM_BLOCK;
 	case PF_R16_UNORM:
 		return VK_FORMAT_R16_UNORM;
 	}


### PR DESCRIPTION
Added support for BC7 Compressed textures that can be compressed with a new python script and loaded by the engine with no problems. The compressed textures are RGBA and stored as `.dds` files. The engine detects when there are compressed textures, so the only thing to do is run the python script and run the engine and everything should work.

Added also some bug fixes with cloud brightness and sun.